### PR TITLE
Add /health endpoint - Fixes #1

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,15 @@
 from fastapi import FastAPI
+from datetime import datetime
 
 app = FastAPI()
 
 @app.get("/")
 def read_root():
     return {"message": "Hello, World!"}
+
+@app.get("/health")
+def health_check():
+    return {
+        "status": "healthy",
+        "timestamp": datetime.utcnow().isoformat() + "Z"
+    }


### PR DESCRIPTION
# Add /health endpoint - Fixes #1

## Summary
Added a new GET endpoint at `/health` that returns the application health status and current timestamp in JSON format. The endpoint responds with:
- `status`: Always returns "healthy" 
- `timestamp`: Current UTC time in ISO format with Z suffix

This implements the basic health check functionality requested in issue #1.

## Review & Testing Checklist for Human
- [ ] Test the `/health` endpoint locally using `uvicorn src.main:app --reload` and verify it returns 200 status
- [ ] Verify the timestamp format meets your requirements (currently uses `datetime.utcnow().isoformat() + "Z"`)
- [ ] Confirm the existing root endpoint `/` still works correctly

### Notes
**Important**: The current implementation uses `datetime.utcnow()` which is deprecated in Python 3.12+. Consider if you'd prefer using `datetime.now(timezone.utc)` for future compatibility.

Requested by: manos (@ntua-el19128)  
Link to Devin run: https://app.devin.ai/sessions/e37f03fe69da4343a42f165eb6c10fbd